### PR TITLE
Fix - Helo in brackets for received header

### DIFF
--- a/core/smtpd_session.go
+++ b/core/smtpd_session.go
@@ -963,12 +963,14 @@ func (s *SMTPServerSession) smtpData(msg []string) {
 	if err == nil {
 		localHost = localHosts[0]
 	}
-	recieved := fmt.Sprintf("Received: from %s (%s)", remoteIP, remoteHost)
+	recieved := "Received: from "
 
 	// helo
 	if len(s.helo) != 0 {
-		recieved += fmt.Sprintf(" (%s)", s.helo)
+		recieved += fmt.Sprintf("%s ", s.helo)
 	}
+
+	recieved += fmt.Sprintf("(%s [%s])", remoteHost, remoteIP)
 
 	// Authentified
 	if s.user != nil {


### PR DESCRIPTION
Previously needed to fix for 2 spamassassin's rules : FSL_HELO_BARE_IP_2 / RCVD_NUMERIC_HELO
