### PR TITLE
Feature/log debug smtp client

### DIFF
--- a/core/smtp_client.go
+++ b/core/smtp_client.go
@@ -226,7 +226,7 @@ func (s *smtpClient) cmd(timeoutSeconds, expectedCode int, format string, args .
 		s.text.StartResponse(id)
 		defer s.text.EndResponse(id)
 		code, msg, err := s.text.ReadResponse(expectedCode)
-		s.logDebug("<", msg)
+		s.logDebug("<", "%d-%s", code, strings.Replace(msg,"\n"," ",-1))
 		return code, msg, err
 	}
 }
@@ -236,7 +236,7 @@ func (s *smtpClient) logDebug(sens string, format string, args ...interface{}) {
 	if !Cfg.GetDebugEnabled() {
 		return
 	}
-	Log.Debug("smtp_client - ", s.conn.RemoteAddr().String(), " - ", sens, " ", fmt.Sprintf(format, args...))
+	Log.Debug("smtp_client -", s.conn.RemoteAddr().String(), "-", sens, fmt.Sprintf(format, args...))
 }
 
 // Extension reports whether an extension is support by the server.

--- a/core/smtp_client.go
+++ b/core/smtp_client.go
@@ -231,6 +231,7 @@ func (s *smtpClient) cmd(timeoutSeconds, expectedCode int, format string, args .
 	}
 }
 
+// logDebug is a log helper for DEBUG log
 func (s *smtpClient) logDebug(sens string, format string, args ...interface{}) {
 	if !Cfg.GetDebugEnabled() {
 		return

--- a/core/smtp_client.go
+++ b/core/smtp_client.go
@@ -210,6 +210,8 @@ func (s *smtpClient) cmd(timeoutSeconds, expectedCode int, format string, args .
 	})
 	defer timer.Stop()
 	go func() {
+		s.logDebug(">", format, args...)
+		
 		id, err = s.text.Cmd(format, args...)
 		done <- true
 	}()
@@ -224,8 +226,16 @@ func (s *smtpClient) cmd(timeoutSeconds, expectedCode int, format string, args .
 		s.text.StartResponse(id)
 		defer s.text.EndResponse(id)
 		code, msg, err := s.text.ReadResponse(expectedCode)
+		s.logDebug("<", msg)
 		return code, msg, err
 	}
+}
+
+func (s *smtpClient) logDebug(sens string, format string, args ...interface{}) {
+	if !Cfg.GetDebugEnabled() {
+		return
+	}
+	Log.Debug("smtp_client - ", s.conn.RemoteAddr().String(), " - ", sens, " ", fmt.Sprintf(format, args...))
 }
 
 // Extension reports whether an extension is support by the server.


### PR DESCRIPTION
Add some DEBUG lines (if DEBUG level activated) to smtp_client (for remote delivery)

Output example :

[mail-1] 2016/10/28 13:06:12.013677 DEBUG - smtp_client - xxx.xxx.xxx.xxx:25 - < 250-xx.mail.example.com STARTTLS PIPELINING 8BITMIME SIZE 50000000 AUTH LOGIN PLAIN CRAM-MD5
[mail-1] 2016/10/28 13:06:12.013904 DEBUG - smtp_client - xxx.xxx.xxx.xxx:25 - > STARTTLS
