### PR TITLE
fixes undefined error

### DIFF
--- a/core/file_formatter.go
+++ b/core/file_formatter.go
@@ -64,7 +64,7 @@ func (f *FileFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {
-		timestampFormat = logrus.DefaultTimestampFormat
+		timestampFormat = time.RFC3339
 	}
 
 	levelText := strings.ToUpper(entry.Level.String())[0:4]


### PR DESCRIPTION

```
» go build                                                                                                                                                                 
# github.com/toorop/tmail/core
core/file_formatter.go:67: undefined: logrus.DefaultTimestampFormat
```
